### PR TITLE
Set social icons to display flex

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -6079,9 +6079,9 @@ p.overview-statement {
   }
 }
 .block__ut-social-links--items {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-box !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   flex-wrap: wrap;
 
   -ms-flex-wrap: wrap;

--- a/src/scss/components/_social-links.scss
+++ b/src/scss/components/_social-links.scss
@@ -2,7 +2,7 @@
 // Social link styles.
 //
 .block__ut-social-links--items {
-  display: flex;
+  display: flex !important;
   flex-wrap: wrap;
   gap: 0;
   grid-gap: 0;


### PR DESCRIPTION
Add important tag to override display:grid to display:flex on social link icons.