### PR TITLE
Remove social icons from subsite page mobile display

### DIFF
--- a/templates/partials/header-subsite.html.twig
+++ b/templates/partials/header-subsite.html.twig
@@ -55,9 +55,6 @@
 								<h2 class="mobile_wordmark">{{ site_slogan }}</h2>
 							</a>
 						</div>
-							<div class="search-social-give d-lg-none">
-								{{ page.header_tertiary }}
-							</div>
 						{# </div> #}
 						<div class="site-navigation site-navigation-main">
 							{{ page.primary_menu }}


### PR DESCRIPTION
Remove social icons from subsite page mobile display due to duplicated id attributes.